### PR TITLE
GuardDuty + Dispatch PoC

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,0 +1,26 @@
+module.exports = {
+  'env': {
+    'node': true,
+    'es6': true
+  },
+  'rules': {
+    'quotes': [2, 'single', {'avoidEscape': true, 'allowTemplateLiterals': true}],
+    'indent': ['error', 2],
+    'no-multi-spaces': [2],
+    'no-unused-vars': [1],
+    'no-mixed-spaces-and-tabs': [2],
+    'no-underscore-dangle': [2],
+    'no-loop-func': [2],
+    'handle-callback-err': [2],
+    'space-unary-ops': [2],
+    'space-in-parens': ['error', 'never'],
+    'space-before-function-paren': ['error', 'never'],
+    'no-trailing-spaces': [2],
+    'no-tabs': [2],
+    'new-cap': [2],
+    'camelcase': [2],
+    'block-spacing': ['error', 'always'],
+    'no-multiple-empty-lines': [2],
+    'semi': ['error', 'always']
+  }
+};

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
   },
   "devDependencies": {
     "eslint": "^4.10.0",
+    "nock": "^9.1.0",
     "tape": "^4.8.0"
   }
 }

--- a/test/functions/minimumThreshold.test.js
+++ b/test/functions/minimumThreshold.test.js
@@ -1,0 +1,62 @@
+'use strict';
+
+const tape = require('tape');
+const minimumThreshold = require('../../minimumThreshold/function.js');
+const AWS = require('aws-sdk');
+const nock = require('nock');
+
+AWS.config.update({
+  'region': 'us-east-1',
+  'sslEnabled': true,
+  'accessKeyId': 'fakeAccessKeyId',
+  'secretAccessKey': 'fakeSecretAccessKey'
+});
+
+process.env.dispatchSnsArn = 'arn:aws:sns:us-east-1:11111:dispatch-incoming'
+process.env.pagerdutyServiceId = 'TEST'
+process.env.minimumThresholdValue = 4
+
+tape('Meets threshold; sends to dispatch', t => {
+
+  const event = {
+    detail: {
+      title: 'test',
+      severity: 6
+    }
+  };
+  const metadataResponse = {
+    ResponseMetadata: {
+      RequestId: 'test-data-test' },
+    MessageId: 'test-data-test'
+  }
+
+  nock('https://sns.us-east-1.amazonaws.com:443', {"encodedQueryParams":true})
+    .post('/', "Action=Publish&Message=%7B%22type%22%3A%22high%22%2C%22body%22%3A%7B%22pagerduty%22%3A%7B%22service%22%3A%22%5C%22TEST%5C%22%22%2C%22title%22%3A%22%5C%22test%5C%22%22%2C%22body%22%3A%22%7B%5C%22title%5C%22%3A%5C%22test%5C%22%2C%5C%22severity%5C%22%3A6%7D%22%7D%7D%7D&TopicArn=arn%3Aaws%3Asns%3Aus-east-1%3A11111%3Adispatch-incoming&Version=2010-03-31")
+    .reply(200, "<PublishResponse xmlns=\"http://sns.amazonaws.com/doc/2010-03-31/\">\n  <PublishResult>\n    <MessageId>test-data-test</MessageId>\n  </PublishResult>\n  <ResponseMetadata>\n    <RequestId>test-data-test</RequestId>\n  </ResponseMetadata>\n</PublishResponse>\n");
+
+  minimumThreshold.fn(event, {}, (err, res) => {
+    t.error(err, 'does not error')
+    t.deepEqual(metadataResponse, res, 'message sent to Dispatch');
+    t.end();
+  })
+});
+
+tape('Does not meet threshold; no dispatch', t => {
+
+  const event = {
+    detail: {
+      title: 'test',
+      severity: 1
+    }
+  };
+
+  nock('https://sns.us-east-1.amazonaws.com:443', {"encodedQueryParams":true})
+    .post('/', "Action=Publish&Message=%7B%22type%22%3A%22high%22%2C%22body%22%3A%7B%22pagerduty%22%3A%7B%22service%22%3A%22%5C%22TEST%5C%22%22%2C%22title%22%3A%22%5C%22test%5C%22%22%2C%22body%22%3A%22%7B%5C%22title%5C%22%3A%5C%22test%5C%22%2C%5C%22severity%5C%22%3A1%7D%22%7D%7D%7D&TopicArn=arn%3Aaws%3Asns%3Aus-east-1%3A11111%3Adispatch-incoming&Version=2010-03-31")
+    .reply(200);
+
+  minimumThreshold.fn(event, {}, (err, res) => {
+    t.error(err, 'does not error')
+    t.deepEqual('Event did not meet minimum threshold requirement.', res, 'message not sent to Dispatch');
+    t.end();
+  })
+});


### PR DESCRIPTION
@ianshward here's the PoC for GuardDuty, integrated with dispatch.

The minimal threshold is set through the Cloudformation template. So it can be configurable to create PagerDuty incidents to low, medium, or high GuardDuty events.

Deployment instructions in the readme are forthcoming. I still need to test if this all works, but I need an actual sample of a Cloudwatch event.