### PR TITLE
revert templates for open-source users

### DIFF
--- a/minimumThreshold/function.template.js
+++ b/minimumThreshold/function.template.js
@@ -37,12 +37,4 @@ const lambdaTemplate = lambdaCfn.build({
   }
 });
 
-delete lambdaTemplate.Parameters.CodeS3Bucket;
-delete lambdaTemplate.Parameters.CodeS3Prefix;
-delete lambdaTemplate.Resources.minimumThreshold.Properties.Environment.Variables.CodeS3Bucket;
-delete lambdaTemplate.Resources.minimumThreshold.Properties.Environment.Variables.CodeS3Prefix;
-
-lambdaTemplate.Resources.minimumThreshold.Properties.Code.S3Bucket = cf.join('-', ['utility', cf.accountId, cf.region]);
-lambdaTemplate.Resources.minimumThreshold.Properties.Code.S3Key = cf.join('', ['bundles/patrol-rules-guardduty/', cf.ref('GitSha'), '.zip']);
-
 module.exports = lambdaTemplate;


### PR DESCRIPTION
Changes made in #4 broke templates for open-source users. This reverts those changes.